### PR TITLE
Implement Niubiz card checkout flow

### DIFF
--- a/indico_payment_niubiz/blueprint.py
+++ b/indico_payment_niubiz/blueprint.py
@@ -1,6 +1,7 @@
 from indico.core.plugins import IndicoPluginBlueprint
 
-from indico_payment_niubiz.controllers import RHNiubizCancel, RHNiubizCallback, RHNiubizSuccess
+from indico_payment_niubiz.controllers import (RHNiubizCancel, RHNiubizCallback, RHNiubizStart,
+                                               RHNiubizSuccess)
 
 blueprint = IndicoPluginBlueprint(
     'payment_niubiz', __name__,
@@ -8,5 +9,6 @@ blueprint = IndicoPluginBlueprint(
 )
 
 blueprint.add_url_rule('/cancel', 'cancel', RHNiubizCancel, methods=('GET', 'POST'))
-blueprint.add_url_rule('/success', 'success', RHNiubizSuccess, methods=('GET', 'POST'))
+blueprint.add_url_rule('/start/<int:reg_id>', 'start', RHNiubizStart, methods=('POST',))
+blueprint.add_url_rule('/success/<int:reg_id>', 'success', RHNiubizSuccess, methods=('GET', 'POST'))
 blueprint.add_url_rule('/callback', 'notify', RHNiubizCallback, methods=('POST',))

--- a/indico_payment_niubiz/controllers.py
+++ b/indico_payment_niubiz/controllers.py
@@ -1,4 +1,7 @@
-from flask import flash, redirect, request
+import logging
+
+import requests
+from flask import flash, redirect, render_template, request
 from flask_pluginengine import current_plugin
 from werkzeug.exceptions import BadRequest
 
@@ -9,6 +12,8 @@ from indico.web.flask.util import url_for
 from indico.web.rh import RH
 
 from indico_payment_niubiz import _
+from indico_payment_niubiz.util import (authorize_transaction, create_session_token,
+                                        get_security_token)
 
 status_map = {
     'COMPLETED': TransactionAction.complete,
@@ -20,10 +25,67 @@ class RHNiubizBase(RH):
     CSRF_ENABLED = False
 
     def _process_args(self):
-        token = request.args['token']
-        self.registration = Registration.query.filter_by(uuid=token).first()
-        if not self.registration:
+        self.event_id = request.view_args['event_id']
+        self.reg_form_id = request.view_args['reg_form_id']
+
+        token = request.args.get('token') or request.form.get('token')
+        reg_id = (request.view_args.get('reg_id') or request.form.get('reg_id') or
+                  request.args.get('reg_id'))
+
+        registration = None
+        if token:
+            registration = Registration.query.filter_by(uuid=token).first()
+        elif reg_id is not None:
+            try:
+                reg_id = int(reg_id)
+            except (TypeError, ValueError):
+                raise BadRequest
+            registration = Registration.query.get(reg_id)
+
+        if not registration or registration.event_id != self.event_id or \
+                registration.registration_form_id != self.reg_form_id:
             raise BadRequest
+
+        self.registration = registration
+        self.event = registration.event
+
+    def _get_endpoint(self):
+        endpoint = current_plugin.settings.get('endpoint')
+        if endpoint in {'sandbox', 'prod'}:
+            return endpoint
+
+        for url in (current_plugin.settings.get('security_url', ''),
+                    current_plugin.settings.get('session_url', '')):
+            if not url:
+                continue
+            url_lower = url.lower()
+            if 'sandbox' in url_lower or 'qas' in url_lower:
+                return 'sandbox'
+        return 'prod'
+
+    def _get_credentials(self):
+        access_key = (current_plugin.settings.get('access_key') or
+                      current_plugin.settings.get('api_username'))
+        secret_key = (current_plugin.settings.get('secret_key') or
+                      current_plugin.settings.get('api_password'))
+        if not access_key or not secret_key:
+            raise BadRequest(_('Niubiz credentials are not configured.'))
+        return access_key, secret_key
+
+    def _get_merchant_id(self):
+        merchant_id = current_plugin.event_settings.get(self.event, 'merchant_id')
+        if not merchant_id:
+            raise BadRequest(_('The Niubiz merchant ID is not configured.'))
+        return merchant_id
+
+    def _get_amount(self):
+        return self.registration.price
+
+    def _get_currency(self):
+        return self.registration.currency or 'PEN'
+
+    def _get_purchase_number(self):
+        return f'{self.registration.event_id}-{self.registration.id}'
 
 
 class RHNiubizCallback(RHNiubizBase):
@@ -42,11 +104,103 @@ class RHNiubizCallback(RHNiubizBase):
 
 class RHNiubizSuccess(RHNiubizBase):
     def _process(self):
-        flash(_('Your payment request has been processed.'), 'success')
-        return redirect(url_for('event_registration.display_regform', self.registration.locator.registrant))
+        transaction_token = (request.form.get('transactionToken') or
+                             request.args.get('transactionToken'))
+        if not transaction_token and request.is_json:
+            transaction_token = (request.json or {}).get('transactionToken')
+        if not transaction_token:
+            raise BadRequest(_('Missing Niubiz transaction token.'))
+
+        try:
+            access_key, secret_key = self._get_credentials()
+            endpoint = self._get_endpoint()
+            access_token = get_security_token(access_key, secret_key, endpoint)
+            authorization = authorize_transaction(
+                self._get_merchant_id(),
+                transaction_token,
+                self._get_purchase_number(),
+                self._get_amount(),
+                self._get_currency(),
+                access_token,
+                endpoint,
+            )
+        except BadRequest:
+            raise
+        except requests.RequestException as exc:
+            logging.getLogger(__name__).exception('Niubiz authorization failed')
+            flash(_('There was a problem confirming your Niubiz payment.'), 'error')
+            return redirect(url_for('event_registration.display_regform',
+                                    self.registration.locator.registrant))
+
+        auth_data = authorization.get('data', {}) if isinstance(authorization, dict) else {}
+        action_code = auth_data.get('ACTION_CODE')
+        action = TransactionAction.complete if action_code == '000' else TransactionAction.reject
+
+        register_transaction(registration=self.registration,
+                             amount=self._get_amount(),
+                             currency=self._get_currency(),
+                             action=action,
+                             provider='niubiz',
+                             data=authorization)
+
+        if action is TransactionAction.complete:
+            flash(_('Your payment was authorized successfully.'), 'success')
+        else:
+            flash(_('Your payment could not be authorized (code {code}).').format(code=action_code),
+                  'error')
+
+        context = {
+            'registration': self.registration,
+            'event': self.event,
+            'amount': self._get_amount(),
+            'currency': self._get_currency(),
+            'merchant_id': self._get_merchant_id(),
+            'purchase_number': self._get_purchase_number(),
+            'authorization': auth_data,
+            'action_code': action_code,
+            'transaction_id': auth_data.get('TRANSACTION_ID'),
+            'masked_card': auth_data.get('CARD'),
+            'success': action is TransactionAction.complete,
+        }
+
+        return render_template('payment_niubiz/event_payment_form.html', **context)
 
 
 class RHNiubizCancel(RHNiubizBase):
     def _process(self):
         flash(_('You cancelled the payment process.'), 'info')
         return redirect(url_for('event_registration.display_regform', self.registration.locator.registrant))
+
+
+class RHNiubizStart(RHNiubizBase):
+    def _process(self):
+        try:
+            access_key, secret_key = self._get_credentials()
+            endpoint = self._get_endpoint()
+            access_token = get_security_token(access_key, secret_key, endpoint)
+            session_key = create_session_token(
+                self._get_merchant_id(),
+                self._get_amount(),
+                self._get_currency(),
+                access_token,
+                endpoint,
+            )
+        except BadRequest:
+            raise
+        except requests.RequestException:
+            logging.getLogger(__name__).exception('Could not create Niubiz session token')
+            flash(_('There was a problem initiating your Niubiz payment.'), 'error')
+            return redirect(url_for('event_registration.display_regform',
+                                    self.registration.locator.registrant))
+
+        context = {
+            'registration': self.registration,
+            'event': self.event,
+            'amount': self._get_amount(),
+            'currency': self._get_currency(),
+            'merchant_id': self._get_merchant_id(),
+            'purchase_number': self._get_purchase_number(),
+            'sessionKey': session_key,
+        }
+
+        return render_template('payment_niubiz/event_payment_form.html', **context)

--- a/indico_payment_niubiz/templates/event_payment_form.html
+++ b/indico_payment_niubiz/templates/event_payment_form.html
@@ -1,24 +1,53 @@
-Clicking on the <strong>Pay now</strong> button you will be redirected to the Niubiz checkout to complete your transaction.
+{% set niubiz_session_key = sessionKey or session_token %}
 
-<dl class="i-data-list">
-    <dt>{% trans %}First name{% endtrans %}</dt>
-    <dd>{{ registration.first_name }}</dd>
-    <dt>{% trans %}Last name{% endtrans %}</dt>
-    <dd>{{ registration.last_name }}</dd>
-    <dt>{% trans %}Total amount{% endtrans %}</dt>
-    <dd>{{ format_currency(amount, currency, locale=session.lang) }}</dd>
-    <dt></dt>
-    <dd>
-        <form id="niubiz-payment" action="{{ return_url }}" method="POST"></form>
-        <script src="https://static-content-qas.vnforapps.com/v2/js/checkout.js"
-                data-sessiontoken="{{ session_token }}"
-                data-channel="web"
-                data-merchantid="{{ merchant_id }}"
-                data-purchasenumber="{{ purchase_number }}"
-                data-amount="{{ amount }}"
-                data-action="{{ return_url }}"
-                data-timeouturl="{{ cancel_url }}"
-                data-merchantlogo="{{ plugin.logo_url }}">
+{% if authorization %}
+    <h3>{% trans %}Niubiz payment details{% endtrans %}</h3>
+    <dl class="i-data-list">
+        <dt>{% trans %}Status{% endtrans %}</dt>
+        <dd>
+            {% if success %}
+                {% trans %}Authorized{% endtrans %}
+            {% else %}
+                {% trans %}Declined{% endtrans %}
+            {% endif %}
+            {% if action_code %}
+                <span class="text-muted">(CODE {{ action_code }})</span>
+            {% endif %}
+        </dd>
+        <dt>{% trans %}Transaction ID{% endtrans %}</dt>
+        <dd>{{ transaction_id or authorization.get('TRANSACTION_ID') }}</dd>
+        <dt>{% trans %}Purchase number{% endtrans %}</dt>
+        <dd>{{ purchase_number }}</dd>
+        <dt>{% trans %}Amount{% endtrans %}</dt>
+        <dd>{{ format_currency(amount, currency or 'PEN', locale=session.lang) }}</dd>
+        <dt>{% trans %}Card{% endtrans %}</dt>
+        <dd>{{ masked_card or authorization.get('CARD') }}</dd>
+    </dl>
+{% else %}
+    <p>{% trans %}Click the button below to pay with Niubiz.{% endtrans %}</p>
+    <form action="{{ url_for('payment_niubiz.start', event_id=event.id, reg_form_id=registration.registration_form.id, reg_id=registration.id) }}"
+          method="post">
+        <button type="submit" class="btn btn-primary">
+            {% trans %}Pay with Niubiz{% endtrans %}
+        </button>
+    </form>
+
+    {% if niubiz_session_key %}
+        <script src="https://static-content-qas.vnforapps.com/v2/js/checkout.js"></script>
+        <script>
+          function launchNiubizCheckout() {
+            VisanetCheckout.configure({
+              sessionkey: "{{ niubiz_session_key }}",
+              channel: "web",
+              merchantid: "{{ merchant_id }}",
+              purchasenumber: "{{ purchase_number }}",
+              amount: "{{ amount }}",
+              callbackurl: "{{ url_for('payment_niubiz.success', event_id=event.id, reg_form_id=registration.registration_form.id, reg_id=registration.id, _external=True) }}"
+            });
+            VisanetCheckout.open();
+          }
+
+          document.addEventListener('DOMContentLoaded', launchNiubizCheckout);
         </script>
-    </dd>
-</dl>
+    {% endif %}
+{% endif %}

--- a/indico_payment_niubiz/util.py
+++ b/indico_payment_niubiz/util.py
@@ -1,14 +1,105 @@
+import base64
+from typing import Any, Dict
+
 import requests
 
 
-def get_security_token(url, username, password):
-    resp = requests.post(url, auth=(username, password))
-    resp.raise_for_status()
-    return resp.json().get('accessToken')
+def _is_legacy_security_args(endpoint: str) -> bool:
+    return endpoint not in {"sandbox", "prod"}
 
 
-def create_session_token(url, security_token, payload):
-    headers = {'Authorization': security_token, 'Content-Type': 'application/json'}
-    resp = requests.post(url, json=payload, headers=headers)
-    resp.raise_for_status()
-    return resp.json().get('sessionKey')
+def _is_legacy_session_args(currency: Any) -> bool:
+    return isinstance(currency, dict)
+
+
+def get_security_token(access_key: str, secret_key: str, endpoint: str = "sandbox") -> str:
+    """Generates a security token from the Niubiz security API."""
+
+    if _is_legacy_security_args(endpoint):
+        resp = requests.post(access_key, auth=(secret_key, endpoint))
+        resp.raise_for_status()
+        try:
+            return resp.json().get("accessToken")
+        except ValueError:
+            return resp.text.strip()
+
+    url = {
+        "sandbox": "https://apisandbox.vnforappstest.com/api.security/v1/security",
+        "prod": "https://apiprod.vnforapps.com/api.security/v1/security",
+    }[endpoint]
+
+    auth = f"{access_key}:{secret_key}".encode("utf-8")
+    headers = {"Authorization": "Basic " + base64.b64encode(auth).decode("utf-8")}
+    response = requests.post(url, headers=headers)
+    response.raise_for_status()
+    return response.text.strip()
+
+
+def create_session_token(
+    merchant_id: str,
+    amount: Any,
+    currency: str,
+    access_token: str,
+    endpoint: str = "sandbox",
+) -> str:
+    """Generates a session token for the Niubiz web checkout."""
+
+    if _is_legacy_session_args(currency):
+        url = merchant_id
+        security_token = amount
+        payload: Dict[str, Any] = currency
+        headers = {"Authorization": security_token, "Content-Type": "application/json"}
+        resp = requests.post(url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return resp.json().get("sessionKey")
+
+    url = {
+        "sandbox": f"https://apisandbox.vnforappstest.com/api.ecommerce/v2/ecommerce/token/session/{merchant_id}",
+        "prod": f"https://apiprod.vnforapps.com/api.ecommerce/v2/ecommerce/token/session/{merchant_id}",
+    }[endpoint]
+
+    headers = {"Content-Type": "application/json", "Authorization": access_token}
+    body = {
+        "channel": "web",
+        "amount": float(amount),
+        "currency": currency,
+        "antifraud": {"clientIp": "127.0.0.1"},
+        "dataMap": {"clientId": "indico-user"},
+    }
+    response = requests.post(url, json=body, headers=headers)
+    response.raise_for_status()
+    return response.json()["sessionKey"]
+
+
+def authorize_transaction(
+    merchant_id: str,
+    transaction_token: str,
+    purchase_number: str,
+    amount: Any,
+    currency: str,
+    access_token: str,
+    endpoint: str = "sandbox",
+) -> Dict[str, Any]:
+    """Authorizes a Niubiz transaction using the checkout transaction token."""
+
+    url = {
+        "sandbox": f"https://apisandbox.vnforappstest.com/api.authorization/v3/authorization/ecommerce/{merchant_id}",
+        "prod": f"https://apiprod.vnforapps.com/api.authorization/v3/authorization/ecommerce/{merchant_id}",
+    }[endpoint]
+
+    headers = {"Content-Type": "application/json", "Authorization": access_token}
+    body = {
+        "channel": "web",
+        "captureType": "manual",
+        "countable": True,
+        "order": {
+            "tokenId": transaction_token,
+            "purchaseNumber": purchase_number,
+            "amount": float(amount),
+            "currency": currency,
+        },
+        "dataMap": {"clientIp": "127.0.0.1"},
+    }
+    response = requests.post(url, json=body, headers=headers)
+    response.raise_for_status()
+    return response.json()

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -1,19 +1,52 @@
 from unittest.mock import patch
 
-from indico_payment_niubiz.util import get_security_token, create_session_token
+from indico_payment_niubiz.util import (authorize_transaction, create_session_token,
+                                        get_security_token)
 
 
-def test_get_security_token():
+def test_get_security_token_sandbox():
     with patch('indico_payment_niubiz.util.requests.post') as post:
-        post.return_value.json.return_value = {'accessToken': 'abc'}
-        token = get_security_token('url', 'u', 'p')
+        post.return_value.text = '  abc  '
+        post.return_value.raise_for_status.return_value = None
+        token = get_security_token('access', 'secret', 'sandbox')
         assert token == 'abc'
-        post.assert_called_once_with('url', auth=('u', 'p'))
+
+        args, kwargs = post.call_args
+        assert args[0] == 'https://apisandbox.vnforappstest.com/api.security/v1/security'
+        assert 'Authorization' in kwargs['headers']
+        assert kwargs['headers']['Authorization'].startswith('Basic ')
 
 
-def test_create_session_token():
+def test_create_session_token_sandbox():
     with patch('indico_payment_niubiz.util.requests.post') as post:
         post.return_value.json.return_value = {'sessionKey': 'xyz'}
-        token = create_session_token('url', 'sec', {'amount': 1})
-        post.assert_called_once_with('url', json={'amount': 1}, headers={'Authorization': 'sec', 'Content-Type': 'application/json'})
+        post.return_value.raise_for_status.return_value = None
+        token = create_session_token('MERCHANT', 10, 'PEN', 'token', 'sandbox')
+
+        args, kwargs = post.call_args
+        assert args[0] == ('https://apisandbox.vnforappstest.com/api.ecommerce/v2/ecommerce/'
+                           'token/session/MERCHANT')
+        assert kwargs['headers'] == {'Content-Type': 'application/json', 'Authorization': 'token'}
+        assert kwargs['json']['amount'] == 10.0
+        assert kwargs['json']['currency'] == 'PEN'
+        assert kwargs['json']['channel'] == 'web'
         assert token == 'xyz'
+
+
+def test_authorize_transaction_sandbox():
+    with patch('indico_payment_niubiz.util.requests.post') as post:
+        response_payload = {'data': {'ACTION_CODE': '000', 'TRANSACTION_ID': 'abc'}}
+        post.return_value.json.return_value = response_payload
+        post.return_value.raise_for_status.return_value = None
+
+        result = authorize_transaction('MERCHANT', 'tx-token', 'PN-1', 50, 'PEN', 'token', 'sandbox')
+
+        args, kwargs = post.call_args
+        assert args[0] == ('https://apisandbox.vnforappstest.com/api.authorization/v3/authorization/'
+                           'ecommerce/MERCHANT')
+        assert kwargs['headers'] == {'Content-Type': 'application/json', 'Authorization': 'token'}
+        assert kwargs['json']['order']['tokenId'] == 'tx-token'
+        assert kwargs['json']['order']['purchaseNumber'] == 'PN-1'
+        assert kwargs['json']['order']['amount'] == 50.0
+        assert kwargs['json']['order']['currency'] == 'PEN'
+        assert result == response_payload


### PR DESCRIPTION
## Summary
- add Niubiz API helpers for security/session/authorization tokens
- implement start/success controllers and update template to launch the checkout
- refresh blueprint, plugin wiring and unit tests for the sandbox flow

## Testing
- pytest *(fails: missing docker module in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c89a57005c83268f1f648cc675b168