### PR TITLE
Finaliza manejo de estados de pago Niubiz

### DIFF
--- a/indico_payment_niubiz/blueprint.py
+++ b/indico_payment_niubiz/blueprint.py
@@ -8,7 +8,7 @@ blueprint = IndicoPluginBlueprint(
     url_prefix='/event/<int:event_id>/registrations/<int:reg_form_id>/payment/response/niubiz'
 )
 
-blueprint.add_url_rule('/cancel', 'cancel', RHNiubizCancel, methods=('GET', 'POST'))
+blueprint.add_url_rule('/cancel/<int:reg_id>', 'cancel', RHNiubizCancel, methods=('GET', 'POST'))
 blueprint.add_url_rule('/start/<int:reg_id>', 'start', RHNiubizStart, methods=('GET', 'POST'))
 blueprint.add_url_rule('/success/<int:reg_id>', 'success', RHNiubizSuccess, methods=('GET', 'POST'))
 blueprint.add_url_rule('/notify', 'notify', RHNiubizCallback, methods=('POST',))

--- a/indico_payment_niubiz/controllers.py
+++ b/indico_payment_niubiz/controllers.py
@@ -240,21 +240,28 @@ class RHNiubizSuccess(RHNiubizBase):
                              data=authorization)
 
         if cancelled:
+            logger.info('Niubiz transaction for registration %s was cancelled by the user.', self.registration.id)
             _apply_registration_status(registration=self.registration, cancelled=True)
         elif expired:
+            logger.info('Niubiz transaction for registration %s expired before completion.', self.registration.id)
             _apply_registration_status(registration=self.registration, expired=True)
         elif success:
+            logger.info('Niubiz transaction for registration %s approved with action code %s.',
+                        self.registration.id, action_code or 'unknown')
             _apply_registration_status(registration=self.registration, paid=True)
         else:
+            logger.info('Niubiz transaction for registration %s rejected with action code %s.',
+                        self.registration.id, action_code or 'unknown')
             _apply_registration_status(registration=self.registration, paid=False)
 
         description = (auth_data.get('ACTION_DESCRIPTION') or auth_data.get('ACTION_MESSAGE') or
                         auth_data.get('actionDescription') or auth_data.get('actionMessage') or '')
 
         if success:
-            flash(_('Your payment was authorized successfully.'), 'success')
+            flash(_('Tu pago fue autorizado correctamente.'), 'success')
         else:
-            message = _('Your payment could not be authorized (code {code}).').format(code=action_code)
+            code_value = action_code or _('desconocido')
+            message = _('Niubiz rechazó tu pago (código {code}).').format(code=code_value)
             if description:
                 message = f'{message} {description}'
             flash(message, 'error')

--- a/tests/niubiz_test.py
+++ b/tests/niubiz_test.py
@@ -1,9 +1,11 @@
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-import requests
+import pytest
+from flask import Flask, request
 
-from indico_payment_niubiz.controllers import _apply_registration_status
-from indico_payment_niubiz.util import authorize_transaction, get_security_token
+from indico_payment_niubiz.controllers import RHNiubizCallback, RHNiubizSuccess
+from indico_payment_niubiz.util import get_security_token
 
 
 def _build_response(*, text='', json_payload=None, status_code=200):
@@ -15,89 +17,159 @@ def _build_response(*, text='', json_payload=None, status_code=200):
     return response
 
 
+@pytest.fixture
+def flask_app():
+    app = Flask(__name__)
+    app.secret_key = 'testing-niubiz'
+    return app
+
+
+def _make_registration():
+    registration = Mock()
+    registration.price = 50
+    registration.currency = 'PEN'
+    registration.event_id = 1
+    registration.id = 10
+    registration.registration_form_id = 2
+    registration.registration_form = SimpleNamespace(id=2)
+    registration.event = SimpleNamespace(id=1)
+    registration.locator = SimpleNamespace(registrant='locator-token')
+    return registration
+
+
 def test_get_security_token_returns_token():
-    response = _build_response(text='  abc  ')
+    response = _build_response(text='  my-token  ')
 
     with patch('indico_payment_niubiz.util.requests.post', return_value=response) as mock_post:
         result = get_security_token('access', 'secret', 'sandbox')
 
     assert result['success'] is True
-    assert result['token'] == 'abc'
+    assert result['token'] == 'my-token'
     mock_post.assert_called_once()
+    response.raise_for_status.assert_called_once()
 
 
-def test_authorization_success_marks_registration_paid():
-    response = _build_response(json_payload={'data': {'ACTION_CODE': '000', 'TRANSACTION_ID': 'abc123'}})
+def test_authorization_success_marks_registration_paid(flask_app, monkeypatch):
+    registration = _make_registration()
+    registration.update_state = Mock()
+    handler = RHNiubizSuccess()
+    handler.registration = registration
+    handler.event = registration.event
 
-    with patch('indico_payment_niubiz.util.requests.post', return_value=response):
-        result = authorize_transaction('MERCHANT', 'tx-token', 'PN-1', 50, 'PEN', 'token', 'sandbox')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_credentials', lambda self: ('access', 'secret'))
+    monkeypatch.setattr(RHNiubizSuccess, '_get_endpoint', lambda self: 'sandbox')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_merchant_id', lambda self: 'MERCHANT')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_purchase_number', lambda self: '1-10')
 
-    assert result['success'] is True
-    assert result['data']['data']['ACTION_CODE'] == '000'
+    token_payload = {'success': True, 'token': 'SEC_TOKEN'}
+    auth_payload = {
+        'data': {
+            'ACTION_CODE': '000',
+            'AUTHORIZATION_CODE': '123456',
+            'TRANSACTION_ID': 'T-100',
+            'TRANSACTION_DATE': '2024-01-01T12:00:00',
+            'CARD': {'PAN': '411111******1111'},
+            'STATUS': 'completed',
+        }
+    }
 
-    registration = Mock()
-    with patch('indico_payment_niubiz.controllers.db.session.flush'):
-        _apply_registration_status(registration=registration, paid=True)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.get_security_token', lambda *a, **k: token_payload)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.authorize_transaction',
+                        lambda *a, **k: {'success': True, 'data': auth_payload})
+    monkeypatch.setattr('indico_payment_niubiz.controllers.register_transaction', lambda **kwargs: None)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.db.session.flush', lambda: None)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.url_for', lambda *a, **k: 'redirect-url')
+
+    flashes = []
+    monkeypatch.setattr('indico_payment_niubiz.controllers.flash', lambda message, category: flashes.append((category, message)))
+
+    rendered = {}
+
+    def fake_render(template_name, **context):
+        rendered['template'] = template_name
+        rendered['context'] = context
+        return context
+
+    monkeypatch.setattr('indico_payment_niubiz.controllers.render_template', fake_render)
+
+    with flask_app.test_request_context('/success/10', method='POST', data={'transactionToken': 'checkout-token'},
+                                        environ_overrides={'REMOTE_ADDR': '198.51.100.10'}):
+        result = handler._process()
 
     registration.update_state.assert_called_once_with(paid=True)
+    assert flashes == [('success', 'Tu pago fue autorizado correctamente.')]
+    assert rendered['template'] == 'payment_niubiz/transaction_details.html'
+    assert result['status_label'] == 'Éxito'
 
 
-def test_authorization_rejection_marks_registration_unpaid():
-    response = _build_response(json_payload={'data': {'ACTION_CODE': '400', 'TRANSACTION_ID': 'def456'}})
+def test_authorization_rejection_marks_registration_rejected(flask_app, monkeypatch):
+    registration = _make_registration()
+    registration.update_state = Mock()
+    handler = RHNiubizSuccess()
+    handler.registration = registration
+    handler.event = registration.event
 
-    with patch('indico_payment_niubiz.util.requests.post', return_value=response):
-        result = authorize_transaction('MERCHANT', 'tx-token', 'PN-2', 50, 'PEN', 'token', 'sandbox')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_credentials', lambda self: ('access', 'secret'))
+    monkeypatch.setattr(RHNiubizSuccess, '_get_endpoint', lambda self: 'sandbox')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_merchant_id', lambda self: 'MERCHANT')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_purchase_number', lambda self: '1-10')
 
-    assert result['success'] is True
-    assert result['data']['data']['ACTION_CODE'] == '400'
+    token_payload = {'success': True, 'token': 'SEC_TOKEN'}
+    auth_payload = {
+        'data': {
+            'ACTION_CODE': '101',
+            'ACTION_DESCRIPTION': 'Tarjeta rechazada',
+            'TRANSACTION_ID': 'T-101',
+            'TRANSACTION_DATE': '2024-01-02T10:30:00',
+            'CARD': {'PAN': '411111******1111'},
+            'STATUS': 'denied',
+        }
+    }
 
-    registration = Mock()
-    with patch('indico_payment_niubiz.controllers.db.session.flush'):
-        _apply_registration_status(registration=registration, paid=False)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.get_security_token', lambda *a, **k: token_payload)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.authorize_transaction',
+                        lambda *a, **k: {'success': True, 'data': auth_payload})
+    monkeypatch.setattr('indico_payment_niubiz.controllers.register_transaction', lambda **kwargs: None)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.db.session.flush', lambda: None)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.url_for', lambda *a, **k: 'redirect-url')
+
+    flashes = []
+    monkeypatch.setattr('indico_payment_niubiz.controllers.flash', lambda message, category: flashes.append((category, message)))
+
+    def fake_render(template_name, **context):
+        return context
+
+    monkeypatch.setattr('indico_payment_niubiz.controllers.render_template', fake_render)
+
+    with flask_app.test_request_context('/success/10', method='POST', data={'transactionToken': 'checkout-token'},
+                                        environ_overrides={'REMOTE_ADDR': '198.51.100.10'}):
+        result = handler._process()
 
     registration.update_state.assert_called_once_with(paid=False)
+    assert flashes == [('error', 'Niubiz rechazó tu pago (código 101). Tarjeta rechazada')]
+    assert result['status_label'] == 'Rechazado'
 
 
-def test_cancellation_marks_registration_withdrawn():
-    registration = Mock()
+def test_notify_expired_marks_registration_expired(flask_app, monkeypatch):
+    registration = _make_registration()
+    registration.update_state = Mock()
 
-    with patch('indico_payment_niubiz.controllers.db.session.flush'):
-        _apply_registration_status(registration=registration, cancelled=True)
+    filter_mock = Mock()
+    filter_mock.first.return_value = registration
+    query_mock = Mock()
+    query_mock.filter_by.return_value = filter_mock
 
-    registration.update_state.assert_called_once_with(withdrawn=True, paid=False)
+    dummy_registration_model = SimpleNamespace(query=query_mock)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.Registration', dummy_registration_model)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.db.session.flush', lambda: None)
 
+    handler = RHNiubizCallback()
 
-def test_authorization_refreshes_token_on_expiration():
-    expired_response = _build_response(status_code=401, json_payload={'error': 'token expired'})
-    http_error = requests.HTTPError('401 error')
-    http_error.response = expired_response
-    expired_response.raise_for_status.side_effect = http_error
+    with flask_app.test_request_context('/notify', method='POST',
+                                        json={'orderId': '1-10', 'statusOrder': 'EXPIRED', 'amount': '10.00', 'currency': 'PEN'}):
+        request.view_args = {'event_id': 1, 'reg_form_id': 2}
+        response = handler._process()
 
-    success_payload = {'data': {'ACTION_CODE': '000', 'TRANSACTION_ID': 'ghi789'}}
-    success_response = _build_response(json_payload=success_payload)
-
-    captured_headers = []
-
-    def post_side_effect(url, json=None, headers=None, timeout=None):
-        captured_headers.append(headers['Authorization'])
-        return expired_response if len(captured_headers) == 1 else success_response
-
-    token_refresher = Mock(return_value={'success': True, 'token': 'new-token'})
-
-    with patch('indico_payment_niubiz.util.requests.post', side_effect=post_side_effect) as mock_post:
-        result = authorize_transaction(
-            'MERCHANT',
-            'tx-token',
-            'PN-3',
-            75,
-            'PEN',
-            'initial-token',
-            'sandbox',
-            token_refresher=token_refresher,
-        )
-
-    assert result['success'] is True
-    assert result['data']['data']['ACTION_CODE'] == '000'
-    assert captured_headers == ['initial-token', 'new-token']
-    assert mock_post.call_count == 2
-    token_refresher.assert_called_once_with()
+    query_mock.filter_by.assert_called_once_with(id=10, event_id=1, registration_form_id=2)
+    registration.update_state.assert_called_once_with(paid=False)
+    assert response == ('', 204)


### PR DESCRIPTION
## Summary
- registrar estados de pago en la ruta de éxito, cancelación y notificaciones de Niubiz
- ampliar los mensajes al usuario y los detalles de la transacción en la interfaz
- reescribir la documentación en español y añadir pruebas unitarias para token, pagos aprobados, rechazados y expirados

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9912608f483268e3cfe392632e885