### PR TITLE
Refactor Niubiz integration with status sync and token cache

### DIFF
--- a/indico_payment_niubiz/templates/event_payment_form.html
+++ b/indico_payment_niubiz/templates/event_payment_form.html
@@ -50,6 +50,7 @@
           checkoutConfig.formbuttoncolor = {{ checkout_button_color|tojson }};
           {% endif %}
           const errorBox = document.getElementById('niubiz-error');
+          const fieldErrorClass = 'niubiz-field-error';
 
           function showCheckoutError(message) {
             if (!errorBox) {
@@ -65,6 +66,50 @@
             }
             errorBox.textContent = '';
             errorBox.classList.add('d-none');
+          }
+
+          function setFieldError(fieldName, message) {
+            if (!fieldName) {
+              showCheckoutError(message);
+              return;
+            }
+            const field = document.querySelector('[data-niubiz-field="' + fieldName + '"]');
+            if (!field) {
+              showCheckoutError(message);
+              return;
+            }
+            const container = field.closest('.form-group, .i-form-group, .mb-3') || field.parentElement;
+            if (!container) {
+              showCheckoutError(message);
+              return;
+            }
+            let feedback = container.querySelector('.' + fieldErrorClass);
+            if (!feedback) {
+              feedback = document.createElement('div');
+              feedback.className = fieldErrorClass + ' invalid-feedback d-block';
+              container.appendChild(feedback);
+            }
+            feedback.textContent = message || '';
+            feedback.classList.toggle('d-none', !message);
+          }
+
+          function clearFieldError(fieldName) {
+            if (!fieldName) {
+              return;
+            }
+            const field = document.querySelector('[data-niubiz-field="' + fieldName + '"]');
+            if (!field) {
+              return;
+            }
+            const container = field.closest('.form-group, .i-form-group, .mb-3') || field.parentElement;
+            if (!container) {
+              return;
+            }
+            const feedback = container.querySelector('.' + fieldErrorClass);
+            if (feedback) {
+              feedback.textContent = '';
+              feedback.classList.add('d-none');
+            }
           }
 
           function buildErrorMessage(error, fallback) {
@@ -106,6 +151,62 @@
             }
           }
 
+          function normaliseChangePayload(event) {
+            if (!event) {
+              return {};
+            }
+            if (event.detail && typeof event.detail === 'object') {
+              return event.detail;
+            }
+            return event;
+          }
+
+          function handlePayformChange(event) {
+            const detail = normaliseChangePayload(event);
+            const fieldName = detail && (detail.field || detail.name || detail.code);
+            if (detail && detail.isValid === false) {
+              const message = detail.message || detail.userMessage || detail.errorMessage ||
+                {{ _('Revisa los datos ingresados en el formulario de pago.')|tojson }};
+              setFieldError(fieldName, message);
+              showCheckoutError(message);
+            } else if (fieldName) {
+              clearFieldError(fieldName);
+              if (!errorBox || errorBox.classList.contains('d-none')) {
+                return;
+              }
+            }
+          }
+
+          function initDetachedPayformListeners() {
+            const payform = (window.Niubiz && window.Niubiz.payform) || window.NiubizPayform || window.payform;
+            if (!payform) {
+              return;
+            }
+            if (typeof payform.on === 'function') {
+              try {
+                payform.on('change', handlePayformChange);
+              } catch (error) {
+                // ignore listener errors silently but keep logging in console
+                console.warn('Niubiz payform change listener could not be registered', error);
+              }
+            }
+            if (typeof payform.createToken === 'function' && !payform.__indicoNiubizWrapped) {
+              const originalCreateToken = payform.createToken.bind(payform);
+              payform.createToken = function() {
+                return originalCreateToken.apply(this, arguments).catch(function(error) {
+                  handleCheckoutError(error);
+                  throw error;
+                });
+              };
+              Object.defineProperty(payform, '__indicoNiubizWrapped', {
+                value: true,
+                enumerable: false,
+                configurable: true,
+                writable: true
+              });
+            }
+          }
+
           function launchNiubizCheckout() {
             clearCheckoutError();
             if (typeof VisanetCheckout === 'undefined' || typeof VisanetCheckout.configure !== 'function') {
@@ -130,6 +231,7 @@
           }
 
           window.launchNiubizCheckout = launchNiubizCheckout;
+          initDetachedPayformListeners();
           if ({% if has_session %}true{% else %}false{% endif %}) {
             document.addEventListener('DOMContentLoaded', function() {
               launchNiubizCheckout();

--- a/indico_payment_niubiz/templates/transaction_details.html
+++ b/indico_payment_niubiz/templates/transaction_details.html
@@ -43,6 +43,8 @@
     <dd>{{ authorization_code_value or '-' }}</dd>
     <dt>{% trans %}Tarjeta enmascarada{% endtrans %}</dt>
     <dd>{{ masked_card_value or '-' }}</dd>
+    <dt>{% trans %}Marca de la tarjeta{% endtrans %}</dt>
+    <dd>{{ card_brand or (payload.get('BRAND') or payload.get('brand') or '-') }}</dd>
     <dt>{% trans %}Fecha y hora{% endtrans %}</dt>
     <dd>{{ transaction_date_value or '-' }}</dd>
     <dt>{% trans %}Monto y moneda{% endtrans %}</dt>
@@ -59,7 +61,7 @@
             {% set status_text = _('Cancelado') %}
         {% elif status_lower in ('expired', 'expirada') %}
             {% set status_text = _('Expirado') %}
-        {% elif status_lower in ('completed', 'complete', 'success', 'successful', 'authorized', 'authorised', 'autorizado', 'autorizada', 'approved') %}
+        {% elif status_lower in ('completed', 'complete', 'success', 'successful', 'authorized', 'authorised', 'autorizado', 'autorizada', 'approved', 'paid') %}
             {% set status_text = _('Autorizado') %}
         {% elif status_lower in ('rejected', 'rechazado', 'denied') %}
             {% set status_text = _('Rechazado') %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,17 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
+import pytest
+
 import indico_payment_niubiz.util as util  # noqa: E402
 import indico_payment_niubiz.controllers as controllers  # noqa: E402
 
 util._ = lambda text: text  # type: ignore
 controllers._ = lambda text: text  # type: ignore
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_cache():
+    util.clear_security_token_cache()
+    yield
+    util.clear_security_token_cache()

--- a/tests/niubiz_test.py
+++ b/tests/niubiz_test.py
@@ -6,8 +6,10 @@ from flask import Flask, request
 
 import requests
 
-from indico_payment_niubiz.controllers import RegistrationState, RHNiubizCallback, RHNiubizSuccess
-from indico_payment_niubiz.util import create_session_token, get_security_token
+from indico_payment_niubiz.controllers import (RegistrationState, RHNiubizCallback, RHNiubizSuccess,
+                                               _apply_registration_status)
+from indico_payment_niubiz.util import (create_session_token, get_security_token,
+                                        query_order_status_by_order_id, query_transaction_status)
 
 
 def _build_response(*, text='', json_payload=None, status_code=200):
@@ -101,7 +103,7 @@ def test_authorization_success_marks_registration_paid(flask_app, monkeypatch):
 
     registration.set_state.assert_called_once_with(RegistrationState.complete)
     registration.update_state.assert_not_called()
-    assert flashes == [('success', 'Tu pago fue autorizado correctamente.')]
+    assert flashes == [('success', '¡Tu pago ha sido procesado con éxito!')]
     assert rendered['template'] == 'payment_niubiz/transaction_details.html'
     assert result['status_label'] == 'Autorizado'
 
@@ -176,7 +178,7 @@ def test_notify_expired_marks_registration_expired(flask_app, monkeypatch):
     query_mock.filter_by.assert_called_once_with(id=10, event_id=1, registration_form_id=2)
     registration.set_state.assert_called_once_with(RegistrationState.unpaid)
     registration.update_state.assert_not_called()
-    assert response == ('', 204)
+    assert response == ('', 200)
 
 
 def test_session_token_refreshes_on_token_expiration(monkeypatch):
@@ -202,3 +204,172 @@ def test_session_token_refreshes_on_token_expiration(monkeypatch):
     assert len(refreshed_tokens) == 1
     assert post_mock.call_count == 2
     assert post_mock.call_args_list[-1][1]['headers']['Authorization'] == 'NEW_TOKEN'
+
+
+def test_get_security_token_uses_cache(monkeypatch):
+    response = _build_response(text='TOKEN_A')
+
+    request_mock = Mock(return_value=response)
+    monkeypatch.setattr('indico_payment_niubiz.util.requests.request', request_mock)
+
+    first = get_security_token('access', 'secret', 'sandbox')
+    second = get_security_token('access', 'secret', 'sandbox')
+
+    assert first['success'] is True
+    assert second['success'] is True
+    assert second.get('cached') is True
+    assert request_mock.call_count == 1
+
+
+def test_get_security_token_force_refresh(monkeypatch):
+    first_response = _build_response(text='TOKEN_A')
+    second_response = _build_response(text='TOKEN_B')
+    request_mock = Mock(side_effect=[first_response, second_response])
+    monkeypatch.setattr('indico_payment_niubiz.util.requests.request', request_mock)
+
+    first = get_security_token('access', 'secret', 'sandbox')
+    second = get_security_token('access', 'secret', 'sandbox', force_refresh=True)
+
+    assert first['token'] == 'TOKEN_A'
+    assert second['token'] == 'TOKEN_B'
+    assert request_mock.call_count == 2
+
+
+def test_query_order_status_success(monkeypatch):
+    response = _build_response(json_payload={'status': 'COMPLETED'})
+    request_mock = Mock(return_value=response)
+    monkeypatch.setattr('indico_payment_niubiz.util.requests.request', request_mock)
+
+    result = query_order_status_by_order_id('MERCHANT', 'ORDER1', 'TOKEN', 'sandbox')
+
+    assert result['success'] is True
+    assert result['status'] == 'COMPLETED'
+    assert request_mock.call_args[0][0] == 'GET'
+    assert 'ORDER1' in request_mock.call_args[0][1]
+
+
+def test_query_order_status_refreshes_token(monkeypatch):
+    expired_response = _build_response(json_payload={'message': 'expired'}, status_code=401)
+    expired_error = requests.exceptions.HTTPError(response=expired_response)
+    expired_response.raise_for_status.side_effect = expired_error
+    success_response = _build_response(json_payload={'status': 'COMPLETED'})
+
+    request_mock = Mock(side_effect=[expired_response, success_response])
+    monkeypatch.setattr('indico_payment_niubiz.util.requests.request', request_mock)
+
+    refreshed = []
+
+    def refresher():
+        refreshed.append(True)
+        return {'success': True, 'token': 'NEW'}
+
+    result = query_order_status_by_order_id('MERCHANT', 'ORDER1', 'OLD', 'sandbox', token_refresher=refresher)
+
+    assert result['success'] is True
+    assert refreshed == [True]
+    assert request_mock.call_count == 2
+    assert request_mock.call_args_list[-1][1]['headers']['Authorization'] == 'NEW'
+
+
+def test_query_transaction_status_success(monkeypatch):
+    response = _build_response(json_payload={'status': 'CANCELED'})
+    request_mock = Mock(return_value=response)
+    monkeypatch.setattr('indico_payment_niubiz.util.requests.request', request_mock)
+
+    result = query_transaction_status('MERCHANT', 'TXN-1', 'TOKEN', 'sandbox')
+
+    assert result['success'] is True
+    assert result['status'] == 'CANCELED'
+    assert request_mock.call_args[0][0] == 'GET'
+    assert 'TXN-1' in request_mock.call_args[0][1]
+
+
+def test_authorization_pending_triggers_status_sync(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = RHNiubizSuccess()
+    handler.registration = registration
+    handler.event = registration.event
+
+    monkeypatch.setattr(RHNiubizSuccess, '_get_credentials', lambda self: ('access', 'secret'))
+    monkeypatch.setattr(RHNiubizSuccess, '_get_endpoint', lambda self: 'sandbox')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_merchant_id', lambda self: 'MERCHANT')
+    monkeypatch.setattr(RHNiubizSuccess, '_get_purchase_number', lambda self: '1-10')
+
+    token_payload = {'success': True, 'token': 'SEC_TOKEN'}
+    auth_payload = {
+        'data': {
+            'ACTION_CODE': '000',
+            'TRANSACTION_ID': 'T-200',
+            'STATUS': 'pending',
+        }
+    }
+
+    monkeypatch.setattr('indico_payment_niubiz.controllers.get_security_token', lambda *a, **k: token_payload)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.authorize_transaction',
+                        lambda *a, **k: {'success': True, 'data': auth_payload})
+    monkeypatch.setattr('indico_payment_niubiz.controllers.register_transaction', lambda **kwargs: None)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.db.session.flush', lambda: None)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.url_for', lambda *a, **k: 'redirect-url')
+
+    flashes = []
+    monkeypatch.setattr('indico_payment_niubiz.controllers.flash',
+                        lambda message, category: flashes.append((category, message)))
+
+    sync_calls = []
+
+    def fake_sync(**kwargs):
+        sync_calls.append(kwargs)
+        _apply_registration_status(registration=registration, paid=True)
+        return {'success': True, 'status': 'COMPLETED'}
+
+    monkeypatch.setattr('indico_payment_niubiz.controllers._synchronise_registration_with_query', fake_sync)
+
+    rendered = {}
+
+    def fake_render(template_name, **context):
+        rendered['template'] = template_name
+        rendered['context'] = context
+        return context
+
+    monkeypatch.setattr('indico_payment_niubiz.controllers.render_template', fake_render)
+
+    with flask_app.test_request_context('/success/10', method='POST', data={'transactionToken': 'checkout-token'}):
+        handler._process()
+
+    assert sync_calls
+    registration.set_state.assert_called_with(RegistrationState.complete)
+    assert flashes[-1] == ('success', '¡Tu pago ha sido procesado con éxito!')
+    assert rendered['template'] == 'payment_niubiz/transaction_details.html'
+
+
+def test_notify_pending_triggers_status_query(flask_app, monkeypatch):
+    registration = _make_registration()
+
+    filter_mock = Mock()
+    filter_mock.first.return_value = registration
+    query_mock = Mock()
+    query_mock.filter_by.return_value = filter_mock
+
+    dummy_registration_model = SimpleNamespace(query=query_mock)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.Registration', dummy_registration_model)
+    monkeypatch.setattr('indico_payment_niubiz.controllers.db.session.flush', lambda: None)
+
+    sync_calls = []
+
+    def fake_sync(**kwargs):
+        sync_calls.append(kwargs)
+        _apply_registration_status(registration=registration, paid=True)
+        return {'success': True, 'status': 'COMPLETED'}
+
+    monkeypatch.setattr('indico_payment_niubiz.controllers._synchronise_registration_with_query', fake_sync)
+
+    handler = RHNiubizCallback()
+
+    with flask_app.test_request_context('/notify', method='POST',
+                                        json={'orderId': '1-10', 'statusOrder': 'PENDING',
+                                              'amount': '10.00', 'currency': 'PEN'}):
+        request.view_args = {'event_id': 1, 'reg_form_id': 2}
+        handler._process()
+
+    assert sync_calls
+    registration.set_state.assert_called_with(RegistrationState.complete)


### PR DESCRIPTION
## Summary
- cache Niubiz security tokens with proactive renewal and add order/transaction query helpers
- synchronise registration states from callbacks and pending authorisations while improving checkout UX messaging
- extend documentation and unit tests covering notifications, token expiry and query flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c1779a1883269c8d8591272a8691