### PR TITLE
Improve Niubiz callback handling and logging

### DIFF
--- a/indico_payment_niubiz/util.py
+++ b/indico_payment_niubiz/util.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import ipaddress
 import logging
-from typing import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 from indico.modules.events.payment.models.transactions import TransactionStatus
 
@@ -33,36 +36,234 @@ CANCELLED_CODES = {"9997", "9905"}
 TIMEOUT_CODES = {"909", "9999"}
 
 
+@dataclass(frozen=True)
+class StatusMapping:
+    """Structured result describing the mapped transaction status."""
+
+    status: TransactionStatus
+    manual_confirmation: bool = False
+    reason: Optional[str] = None
+
+
+def _collect_dicts(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return a flat list with every nested dictionary in ``payload``."""
+
+    if not isinstance(payload, dict):
+        return []
+
+    seen: set[int] = set()
+    stack: List[Dict[str, Any]] = [payload]
+    result: List[Dict[str, Any]] = []
+
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        result.append(current)
+        for value in current.values():
+            if isinstance(value, dict):
+                stack.append(value)
+            elif isinstance(value, list):
+                stack.extend(item for item in value if isinstance(item, dict))
+
+    return result
+
+
+def _extract_value(payload: Dict[str, Any], *keys: str) -> Optional[Any]:
+    """Try to retrieve the first existing key from the payload hierarchy."""
+
+    dictionaries = _collect_dicts(payload)
+    for dictionary in dictionaries:
+        for key in keys:
+            if key in dictionary and dictionary[key] not in (None, ""):
+                return dictionary[key]
+            upper = key.upper()
+            if upper in dictionary and dictionary[upper] not in (None, ""):
+                return dictionary[upper]
+            lower = key.lower()
+            if lower in dictionary and dictionary[lower] not in (None, ""):
+                return dictionary[lower]
+    return None
+
+
+def extract_callback_details(payload: Dict[str, Any]) -> Dict[str, Optional[Any]]:
+    """Normalize raw Niubiz callback payloads into a flat dictionary."""
+
+    if not isinstance(payload, dict):
+        return {}
+
+    details: Dict[str, Optional[Any]] = {
+        "purchase_number": _extract_value(
+            payload,
+            "purchaseNumber",
+            "purchase_number",
+            "orderId",
+            "order_id",
+        ),
+        "transaction_id": _extract_value(
+            payload,
+            "transactionId",
+            "transaction_id",
+            "TRANSACTION_ID",
+            "operationNumber",
+            "operation_number",
+        ),
+        "status": _extract_value(payload, "status", "STATUS"),
+        "status_order": _extract_value(payload, "statusOrder", "status_order"),
+        "action_code": _extract_value(payload, "actionCode", "ACTION_CODE"),
+        "action_description": _extract_value(
+            payload,
+            "actionDescription",
+            "ACTION_DESCRIPTION",
+            "message",
+            "detalle",
+        ),
+        "transaction_date": _extract_value(payload, "transactionDate", "TRANSACTION_DATE"),
+        "amount": _extract_value(payload, "amount"),
+        "currency": _extract_value(payload, "currency"),
+        "authorization_code": _extract_value(payload, "authorizationCode", "AUTHORIZATION_CODE"),
+        "trace_number": _extract_value(payload, "traceNumber", "TRACE_NUMBER"),
+        "brand": _extract_value(payload, "brand", "BRAND"),
+        "masked_card": _extract_value(payload, "maskedCard", "masked_card", "PAN", "pan"),
+        "eci": _extract_value(payload, "eci", "ECI"),
+        "cip": _extract_value(payload, "cip", "CIP"),
+        "operation_number": _extract_value(payload, "operationNumber", "operation_number"),
+        "payment_method": _extract_value(payload, "paymentMethod", "payment_method"),
+        "channel": _extract_value(payload, "channel"),
+    }
+
+    # ``purchaseNumber`` is sometimes nested within ``order`` and should override
+    # the ``orderId`` fallback when available.
+    order_purchase = _extract_value(payload, "purchaseNumber", "purchase_number")
+    if order_purchase:
+        details["purchase_number"] = order_purchase
+
+    return details
+
+
+def validate_nbz_signature(secret: str, body: bytes, signature: str) -> bool:
+    """Validate the ``NBZ-Signature`` header using HMAC SHA-256."""
+
+    if not secret or not signature:
+        return False
+
+    computed = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    provided = signature.strip().lower()
+    return hmac.compare_digest(provided, computed.lower())
+
+
 def get_checkout_script_url(endpoint: str = "sandbox") -> str:
     endpoint_key = "sandbox" if (endpoint or "sandbox").lower() == "sandbox" else "prod"
     return CHECKOUT_JS_URLS[endpoint_key]
 
 
+def map_niubiz_status(
+    *,
+    status: Optional[str],
+    action_code: Optional[str] = None,
+    status_order: Optional[str] = None,
+    payment_method: Optional[str] = None,
+    action_description: Optional[str] = None,
+) -> StatusMapping:
+    """Map Niubiz fields into the internal :class:`TransactionStatus` enum."""
+
+    status_value = (status or "").strip()
+    status_lower = status_value.lower()
+    status_order_value = (status_order or "").strip()
+    status_order_lower = status_order_value.lower()
+    action_code_value = (action_code or "").strip()
+    action_code_upper = action_code_value.upper()
+    payment_method_lower = (payment_method or "").strip().lower()
+    action_description_lower = (action_description or "").strip().lower()
+
+    manual_confirmation = False
+
+    # ``statusOrder`` appears on Pago Link callbacks.
+    if status_order_lower == "completed":
+        return StatusMapping(TransactionStatus.successful)
+    if status_order_lower in {"expired", "cancelled", "canceled"}:
+        return StatusMapping(TransactionStatus.cancelled)
+    if status_order_lower == "pending":
+        return StatusMapping(TransactionStatus.pending)
+
+    if status_lower == "confirmed":
+        manual_confirmation = True
+        return StatusMapping(TransactionStatus.successful, manual_confirmation=manual_confirmation)
+
+    if status_lower == "authorized":
+        if action_code_upper == "000":
+            return StatusMapping(TransactionStatus.successful)
+        return StatusMapping(TransactionStatus.failed)
+
+    if status_lower in {"captured", "paid", "completed", "approved", "success"}:
+        return StatusMapping(TransactionStatus.successful)
+
+    if status_lower in {"not authorized", "not_authorized", "denied", "declined"}:
+        return StatusMapping(TransactionStatus.failed)
+
+    if status_lower == "review":
+        return StatusMapping(TransactionStatus.pending)
+
+    if status_lower in {"pending", "pendiente"}:
+        return StatusMapping(TransactionStatus.pending)
+
+    if status_lower in {"generated", "generado", "generada"}:
+        return StatusMapping(TransactionStatus.pending)
+
+    if status_lower in {"voided", "void", "anulado", "anulada"}:
+        return StatusMapping(TransactionStatus.cancelled)
+
+    if status_lower in {"cancelled", "canceled"}:
+        return StatusMapping(TransactionStatus.cancelled)
+
+    if status_lower in {"expired", "expirado", "expirada"}:
+        return StatusMapping(TransactionStatus.cancelled)
+
+    if status_lower in {"rejected"}:
+        return StatusMapping(TransactionStatus.failed)
+
+    if status_lower in {"failed", "error"}:
+        return StatusMapping(TransactionStatus.failed)
+
+    if action_description_lower:
+        if "cip" in action_description_lower and any(
+            keyword in action_description_lower for keyword in ("gener", "pend", "esper")
+        ):
+            return StatusMapping(TransactionStatus.pending)
+        if "yape" in action_description_lower and any(
+            keyword in action_description_lower for keyword in ("esper", "pending", "pend", "wait")
+        ):
+            return StatusMapping(TransactionStatus.pending)
+        if any(keyword in action_description_lower for keyword in ("anulad", "void")):
+            return StatusMapping(TransactionStatus.cancelled)
+
+    if payment_method_lower:
+        if "pagoefectivo" in payment_method_lower or "pago efectivo" in payment_method_lower:
+            return StatusMapping(TransactionStatus.pending)
+        if "yape" in payment_method_lower:
+            if action_code_upper != "000" or status_lower in {"pending", "review", "", "authorized"}:
+                return StatusMapping(TransactionStatus.pending)
+
+    if action_code_upper in CANCELLED_CODES or action_code_upper in TIMEOUT_CODES:
+        return StatusMapping(TransactionStatus.cancelled)
+
+    if action_code_upper in REJECTED_CODES or action_code_upper in FAILED_CODES:
+        return StatusMapping(TransactionStatus.failed)
+
+    if action_code_upper and action_code_upper != "000":
+        return StatusMapping(TransactionStatus.failed)
+
+    if action_code_upper == "000":
+        return StatusMapping(TransactionStatus.pending)
+
+    return StatusMapping(TransactionStatus.pending)
+
+
 def map_action_code_to_status(action_code: str, status: str) -> TransactionStatus:
-    """Map Niubiz action/status codes to the Indico :class:`TransactionStatus` enum."""
+    """Compatibility wrapper around :func:`map_niubiz_status`."""
 
-    normalized_code = (action_code or "").strip()
-    normalized_status = (status or "").strip().lower()
-
-    if normalized_code == "000" or normalized_status == "authorized":
-        return TransactionStatus.successful
-
-    if normalized_status in {"confirmed", "captured", "paid", "completed"}:
-        return TransactionStatus.successful
-
-    if normalized_status in {"cancelled", "canceled"} or normalized_code in CANCELLED_CODES:
-        return TransactionStatus.cancelled
-
-    if normalized_status in {"expired", "timeout"} or normalized_code in TIMEOUT_CODES:
-        return TransactionStatus.expired
-
-    if normalized_code in REJECTED_CODES or normalized_status in {"rejected", "denied"}:
-        return TransactionStatus.rejected
-
-    if normalized_code in FAILED_CODES or normalized_status in {"failed", "error"}:
-        return TransactionStatus.failed
-
-    return TransactionStatus.error
+    return map_niubiz_status(status=status, action_code=action_code).status
 
 
 def parse_ip_list(values: Sequence[str]) -> Sequence[ipaddress._BaseNetwork]:  # type: ignore[name-defined]

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,272 @@
+import hashlib
+import json
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from flask import Flask, request
+
+from indico_payment_niubiz.controllers import RHNiubizCallback
+
+
+def _make_registration():
+    registration = Mock()
+    registration.id = 10
+    registration.price = Decimal("50")
+    registration.currency = "PEN"
+    registration.event_id = 1
+    registration.registration_form_id = 2
+    registration.event = SimpleNamespace(id=1)
+    registration.user = SimpleNamespace(id=5)
+    return registration
+
+
+@pytest.fixture
+def flask_app():
+    app = Flask(__name__)
+    app.secret_key = "testing-niubiz"
+    return app
+
+
+def _mock_registration_lookup(monkeypatch, registration):
+    def _filter_by(**kwargs):
+        matches = (
+            kwargs.get("id") == registration.id
+            and kwargs.get("event_id") == registration.event_id
+            and kwargs.get("registration_form_id") == registration.registration_form_id
+        )
+        return SimpleNamespace(first=lambda: registration if matches else None)
+
+    monkeypatch.setattr(
+        "indico_payment_niubiz.controllers.Registration",
+        SimpleNamespace(query=SimpleNamespace(filter_by=_filter_by)),
+    )
+
+
+def _build_handler(monkeypatch, registration, settings=None):
+    handler = RHNiubizCallback()
+    _mock_registration_lookup(monkeypatch, registration)
+    values = settings or {}
+
+    def _fake_setting(self, name):
+        return values.get(name, "")
+
+    monkeypatch.setattr(RHNiubizCallback, "_get_scoped_setting", _fake_setting)
+    monkeypatch.setattr(RHNiubizCallback, "_get_credentials", lambda self: ("ACCESS", values.get("__secret__", "secret")))
+    return handler
+
+
+def test_callback_successful_payment(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration)
+
+    success_calls = {}
+    log_entries = []
+
+    def fake_success(registration, **kwargs):
+        success_calls.update(kwargs)
+
+    def fake_log(registration, summary, *, kind, data, meta=None):
+        log_entries.append({"summary": summary, "data": data, "kind": kind})
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", fake_success)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", fake_log)
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "T-1",
+        "STATUS": "Authorized",
+        "ACTION_CODE": "000",
+        "amount": "50.00",
+        "currency": "PEN",
+        "transactionDate": "2024-01-01T10:00:00",
+        "actionDescription": "Autorizado automáticamente",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        handler._process()
+
+    assert success_calls["transaction_id"] == "T-1"
+    assert success_calls["status"] == "Authorized"
+    assert success_calls["data"]["action_description"] == "Autorizado automáticamente"
+    assert any(entry["data"].get("mappedStatus") == "successful" for entry in log_entries)
+
+
+def test_callback_failed_payment(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration)
+
+    failure_calls = {}
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", lambda *a, **k: None)
+
+    def fake_failed(registration, **kwargs):
+        failure_calls.update(kwargs)
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", fake_failed)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", lambda *a, **k: None)
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "T-2",
+        "STATUS": "Not Authorized",
+        "ACTION_CODE": "101",
+        "amount": "50",
+        "currency": "PEN",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        handler._process()
+
+    assert failure_calls["status"] == "Not Authorized"
+    assert failure_calls["transaction_id"] == "T-2"
+
+
+def test_callback_pagoefectivo_pending(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration)
+
+    pending_calls = {}
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", lambda *a, **k: None)
+
+    def fake_record(**kwargs):
+        pending_calls.update(kwargs)
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", fake_record)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", lambda *a, **k: None)
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "PE-1",
+        "status": "PENDING",
+        "channel": "pagoefectivo",
+        "cip": "12345678",
+        "operationNumber": "OP-1",
+        "currency": "PEN",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        handler._process()
+
+    assert pending_calls["action"].name == "pending"
+    assert pending_calls["data"]["cip"] == "12345678"
+
+
+def test_callback_pagoefectivo_expired(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration)
+
+    failure_calls = {}
+
+    def fake_failed(registration, **kwargs):
+        failure_calls.update(kwargs)
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", fake_failed)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", lambda *a, **k: None)
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "PE-2",
+        "status": "EXPIRED",
+        "channel": "pagoefectivo",
+        "operationNumber": "OP-2",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        handler._process()
+
+    assert failure_calls["cancelled"] is True
+
+
+def test_callback_missing_transaction_id_returns_400(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration)
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", lambda *a, **k: None)
+
+    payload = {"purchaseNumber": "1-10", "STATUS": "AUTHORIZED", "ACTION_CODE": "000"}
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        result = handler._process()
+
+    assert result == ("", 400)
+
+
+def test_callback_invalid_signature_returns_401(flask_app, monkeypatch):
+    registration = _make_registration()
+    settings = {"callback_hmac_secret": "secret"}
+    handler = _build_handler(monkeypatch, registration, settings=settings)
+
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", lambda *a, **k: None)
+
+    payload = {"purchaseNumber": "1-10", "transactionId": "T-1", "STATUS": "AUTHORIZED"}
+    body = json.dumps(payload)
+    signature = hashlib.sha256(b"invalid").hexdigest()
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=body,
+        content_type="application/json",
+        headers={"NBZ-Signature": signature},
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        result = handler._process()
+
+    assert result == ("", 401)


### PR DESCRIPTION
## Summary
- add utilities to normalize callback payloads, validate HMAC signatures and map Niubiz statuses to Indico states
- harden `RHNiubizCallback` with signature/token/IP checks, detailed logging, and explicit state handling for success, failure, pending and cancellations
- replace refund integration with a placeholder log message and extend the test suite with dedicated callback scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9e8cfbcf0832681428e686367fd56