### PR TITLE
Refactor Niubiz endpoints and add tests

### DIFF
--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,0 +1,188 @@
+import json
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from flask import Flask, request
+
+from indico.modules.events.payment.models.transactions import TransactionStatus
+
+from indico_payment_niubiz.controllers import RHNiubizCallback
+
+
+def _make_registration():
+    registration = Mock()
+    registration.id = 10
+    registration.event_id = 1
+    registration.registration_form_id = 2
+    registration.price = Decimal("50")
+    registration.currency = "PEN"
+    registration.event = SimpleNamespace(id=1)
+    registration.user = SimpleNamespace(id=5)
+    registration.set_paid = Mock()
+    return registration
+
+
+def _patch_registration_lookup(monkeypatch, registration):
+    def _filter_by(**kwargs):
+        matches = (
+            kwargs.get("id") == registration.id
+            and kwargs.get("event_id") == registration.event_id
+            and kwargs.get("registration_form_id") == registration.registration_form_id
+        )
+        return SimpleNamespace(first=lambda: registration if matches else None)
+
+    fake_registration = SimpleNamespace(
+        query=SimpleNamespace(filter_by=_filter_by),
+        get=lambda reg_id: registration if reg_id == registration.id else None,
+    )
+    monkeypatch.setattr("indico_payment_niubiz.controllers.Registration", fake_registration)
+
+
+def _patch_db(monkeypatch):
+    commits = []
+
+    def _commit():
+        commits.append(True)
+
+    fake_db = SimpleNamespace(session=SimpleNamespace(commit=_commit))
+    monkeypatch.setattr("indico_payment_niubiz.controllers.db", fake_db)
+    return commits
+
+
+def _build_handler(monkeypatch, registration, mapped_status):
+    handler = RHNiubizCallback()
+    _patch_registration_lookup(monkeypatch, registration)
+
+    settings = {
+        "callback_ip_whitelist": "",
+        "callback_authorization_token": "",
+        "callback_hmac_secret": "secret",
+    }
+
+    def _get_setting(self, name):
+        return settings.get(name)
+
+    monkeypatch.setattr(RHNiubizCallback, "_get_scoped_setting", _get_setting)
+    monkeypatch.setattr(RHNiubizCallback, "_get_credentials", lambda self: ("ACCESS", "secret"))
+    monkeypatch.setattr(
+        "indico_payment_niubiz.controllers.map_niubiz_status",
+        lambda **kwargs: SimpleNamespace(status=mapped_status, manual_confirmation=False),
+    )
+    monkeypatch.setattr("indico_payment_niubiz.controllers.build_transaction_data", lambda **kwargs: {})
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_successful_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.handle_failed_payment", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.record_payment_transaction", lambda *a, **k: None)
+    monkeypatch.setattr("indico_payment_niubiz.controllers.log_registration_event", lambda *a, **k: None)
+    return handler
+
+
+@pytest.fixture
+def flask_app():
+    app = Flask(__name__)
+    app.secret_key = "testing-niubiz"
+    return app
+
+
+def test_callback_marks_registration_paid(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration, TransactionStatus.successful)
+    commits = _patch_db(monkeypatch)
+    monkeypatch.setattr(
+        "indico_payment_niubiz.controllers.validate_nbz_signature",
+        lambda secret, body, signature: True,
+    )
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "T-1",
+        "status": "Authorized",
+        "ACTION_CODE": "000",
+        "amount": "50.00",
+        "currency": "PEN",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        headers={"NBZ-Signature": "valid"},
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        result = handler._process()
+
+    assert result == ("", 200)
+    registration.set_paid.assert_called_once_with(True)
+    assert len(commits) == 1
+
+
+def test_callback_marks_registration_unpaid_on_refund(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration, TransactionStatus.cancelled)
+    commits = _patch_db(monkeypatch)
+    monkeypatch.setattr(
+        "indico_payment_niubiz.controllers.validate_nbz_signature",
+        lambda secret, body, signature: True,
+    )
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "T-2",
+        "status": "Refunded",
+        "amount": "50.00",
+        "currency": "PEN",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        headers={"NBZ-Signature": "valid"},
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        result = handler._process()
+
+    assert result == ("", 200)
+    registration.set_paid.assert_called_once_with(False)
+    assert len(commits) == 1
+
+
+def test_callback_invalid_signature_rejected(flask_app, monkeypatch):
+    registration = _make_registration()
+    handler = _build_handler(monkeypatch, registration, TransactionStatus.successful)
+    commits = _patch_db(monkeypatch)
+    monkeypatch.setattr(
+        "indico_payment_niubiz.controllers.validate_nbz_signature",
+        lambda secret, body, signature: False,
+    )
+
+    payload = {
+        "purchaseNumber": "1-10",
+        "transactionId": "T-3",
+        "status": "Authorized",
+        "amount": "50.00",
+        "currency": "PEN",
+    }
+
+    with flask_app.test_request_context(
+        "/notify",
+        method="POST",
+        data=json.dumps(payload),
+        content_type="application/json",
+        headers={"NBZ-Signature": "invalid"},
+        environ_overrides={"REMOTE_ADDR": "200.48.119.10", "wsgi.url_scheme": "https"},
+    ):
+        request.view_args = {"event_id": registration.event_id, "reg_form_id": registration.registration_form_id}
+        handler._process_args()
+        result = handler._process()
+
+    assert result == ("", 401)
+    assert not registration.set_paid.called
+    assert len(commits) == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+import requests
+
+from indico_payment_niubiz.client import NiubizClient
+
+
+class DummyResponse:
+    def __init__(self, *, json_payload=None, text="", status_code=200):
+        self._json_payload = json_payload
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        if self._json_payload is None:
+            raise ValueError
+        return self._json_payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+
+def test_authorize_transaction_success(monkeypatch):
+    security_response = DummyResponse(json_payload={"accessToken": "sec-token", "expiresIn": 600})
+    authorization_payload = {
+        "data": {
+            "order": {
+                "STATUS": "Authorized",
+                "ACTION_CODE": "000",
+                "TRANSACTION_ID": "T-123",
+                "AUTHORIZATION_CODE": "654321",
+            },
+            "card": {"BRAND": "VISA", "PAN": "411111******1111"},
+            "traceNumber": "TRACE-1",
+        }
+    }
+    authorization_response = DummyResponse(json_payload=authorization_payload)
+
+    calls = []
+
+    def fake_request(method, url, headers=None, json=None, timeout=None):
+        if "api.security" in url:
+            return security_response
+        calls.append(SimpleNamespace(method=method, url=url, headers=headers, json=json))
+        return authorization_response
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    client = NiubizClient(merchant_id="MERCHANT", access_key="ACCESS", secret_key="SECRET", endpoint="sandbox")
+
+    result = client.authorize_transaction(
+        transaction_token="TOKEN-123",
+        purchase_number="ORDER-1",
+        amount=10.5,
+        currency="PEN",
+        client_ip="203.0.113.20",
+        client_id="client-abc",
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "Authorized"
+    assert result["transaction_id"] == "T-123"
+    assert result["trace_number"] == "TRACE-1"
+    assert result["brand"] == "VISA"
+    assert result["access_token"] == "sec-token"
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.method == "POST"
+    assert call.url.endswith("/api.authorization/v3/authorization/ecommerce/MERCHANT")
+    assert call.headers["Authorization"] == "sec-token"
+    assert call.json["order"]["purchaseNumber"] == "ORDER-1"
+    assert call.json["order"]["tokenId"] == "TOKEN-123"
+    assert call.json["order"]["amount"] == 10.5
+    assert call.json["order"]["currency"] == "PEN"
+    assert call.json["dataMap"]["clientIp"] == "203.0.113.20"
+    assert call.json["dataMap"]["clientId"] == "client-abc"
+
+
+def test_refund_transaction_success(monkeypatch):
+    security_response = DummyResponse(json_payload={"accessToken": "sec-token", "expiresIn": 600})
+    refund_payload = {"data": {"STATUS": "Refunded", "transactionId": "T-1"}}
+    refund_response = DummyResponse(json_payload=refund_payload)
+
+    calls = []
+
+    def fake_request(method, url, headers=None, json=None, timeout=None):
+        if "api.security" in url:
+            return security_response
+        calls.append(SimpleNamespace(method=method, url=url, headers=headers, json=json))
+        return refund_response
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    client = NiubizClient(merchant_id="MERCHANT", access_key="ACCESS", secret_key="SECRET", endpoint="sandbox")
+
+    result = client.refund_transaction(
+        transaction_id="T-1",
+        amount=25,
+        currency="PEN",
+        reason="Customer request",
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "Refunded"
+    assert result["transaction_id"] == "T-1"
+    assert result["access_token"] == "sec-token"
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.method == "POST"
+    assert call.url.endswith("/api.refund/v1/refund/MERCHANT/T-1")
+    assert call.headers["Authorization"] == "sec-token"
+    assert call.json == {"amount": 25.0, "currency": "PEN", "reason": "Customer request"}
+
+
+def test_reverse_transaction_success(monkeypatch):
+    security_response = DummyResponse(json_payload={"accessToken": "sec-token", "expiresIn": 600})
+    reversal_payload = {"data": {"STATUS": "Voided", "transactionId": "T-2"}}
+    reversal_response = DummyResponse(json_payload=reversal_payload)
+
+    calls = []
+
+    def fake_request(method, url, headers=None, json=None, timeout=None):
+        if "api.security" in url:
+            return security_response
+        calls.append(SimpleNamespace(method=method, url=url, headers=headers, json=json))
+        return reversal_response
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    client = NiubizClient(merchant_id="MERCHANT", access_key="ACCESS", secret_key="SECRET", endpoint="sandbox")
+
+    result = client.reverse_transaction(transaction_id="T-2", amount=30, currency="PEN")
+
+    assert result["success"] is True
+    assert result["status"] == "Voided"
+    assert result["transaction_id"] == "T-2"
+    assert result["access_token"] == "sec-token"
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.method == "POST"
+    assert call.url.endswith("/api.authorization/v3/reverse/ecommerce/MERCHANT")
+    assert call.headers["Authorization"] == "sec-token"
+    assert call.json == {"transactionId": "T-2", "amount": 30.0, "currency": "PEN"}


### PR DESCRIPTION
## Summary
- update the Niubiz client to use the official confirmation, reversal and refund endpoints while removing unsupported status queries
- toggle the registration payment flag from the callback handler based on Niubiz statuses
- add unit tests for the client and callback flows and document the supported flows, integration behaviour and test instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca0569f2788326a44d4ae80cca4f66